### PR TITLE
Add option to skip specific JIRA fields & adding task for Contrast Security.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec :name => "owasp-glue"
 gem "rake"
 gem "rspec"
 gem 'aruba', '~> 0.14.2'
+gem 'httparty'

--- a/lib/glue.rb
+++ b/lib/glue.rb
@@ -131,18 +131,26 @@ module Glue
   #Determine output formats based on options[:output_formats]
   #or options[:output_files]
   def self.get_output_format options
+    res = [ ]
+
     if options[:output_file]
-      get_format_from_output_file options[:output_file]
-    elsif options[:output_format]
-      get_format_from_output_format options[:output_format]
-    else
+      res << get_format_from_output_file(options[:output_file])
+    end
+    
+    if options[:output_format]
+      res << get_format_from_output_format(options[:output_format])
+    end
+
+    if res.empty?
       begin
         require 'terminal-table'
-        return [:to_s]
+        res << :to_s
       rescue LoadError
-        return [:to_json]
+        res << :to_json
       end
     end
+
+    res.flatten
   end
 
   def self.get_format_from_output_format output_format

--- a/lib/glue/filters/jira_one_time_filter.rb
+++ b/lib/glue/filters/jira_one_time_filter.rb
@@ -13,7 +13,7 @@ class Glue::JiraOneTimeFilter < Glue::BaseFilter
 
   def filter tracker
 
-    if tracker.options[:output_format].first != @format
+    if !tracker.options[:output_format].include?(@format)
       return  # Bail in the case where JIRA isn't being used.
     end
     Glue.debug "Have #{tracker.findings.count} items pre JIRA One Time filter."
@@ -42,7 +42,8 @@ class Glue::JiraOneTimeFilter < Glue::BaseFilter
   private
   def confirm_new finding
     count = 0
-    @jira.Issue.jql("project=#{@project} AND description ~ '#{finding.fingerprint}'").each do |issue|
+    
+    @jira.Issue.jql("project=#{@project} AND description ~ '#{finding.fingerprint}' AND resolution is EMPTY").each do |issue|
       count = count + 1  # Must have at least 1 issue with fingerprint.
     end
     Glue.debug "Found #{count} items for #{finding.description}"

--- a/lib/glue/filters/pivotal_one_time_filter.rb
+++ b/lib/glue/filters/pivotal_one_time_filter.rb
@@ -17,7 +17,7 @@ class Glue::PivotalOneTimeFilter < Glue::BaseFilter
 #  curl -X GET -H "X-TrackerToken: $TOKEN" "https://www.pivotaltracker.com/services/v5/projects/$PROJECT_ID/stories?date_format=millis&filter=label%3Aplans"
 
   def filter tracker
-    if tracker.options[:output_format].first != @format
+    if !tracker.options[:output_format].include?(@format)
       return  # Bail in the case where JIRA isn't being used.
     end
     @project = tracker.options[:pivotal_project]

--- a/lib/glue/options.rb
+++ b/lib/glue/options.rb
@@ -134,6 +134,9 @@ module Glue::Options
         opts.on "--jira-component COMPONENT", "Specify the JIRA component to use." do |component|
           options[:jira_component] = component
         end
+        opts.on "--jira-skip-fields FIELDS", "Specify any JIRA fields to skip (separate with commas)." do |skip_fields|
+          options[:jira_skip_fields] = skip_fields
+        end
 
         opts.separator ""
         opts.separator "Pivotal options:"
@@ -199,6 +202,27 @@ module Glue::Options
         opts.separator "OWASP Dependency Check options:"
         opts.on "--owasp-dep-check-path PATH", "The full path to the OWASP Dependency Check script" do |path|
           options[:owasp_dep_check_path] = path
+        end
+
+        opts.separator ""
+        opts.separator "Contrast Security options:"
+        opts.on "--contrast-api-key API_KEY", "Contrast API key" do |contrast_api_key|
+          options[:contrast_api_key] = contrast_api_key
+        end
+        opts.on "--contrast-service-key SERVICE_KEY", "Contrast service key" do |contrast_service_key|
+          options[:contrast_service_key] = contrast_service_key
+        end
+        opts.on "--contrast-org-id ORG_ID", "Contrast organization ID" do |contrast_org_id|
+          options[:contrast_org_id] = contrast_org_id
+        end
+        opts.on "--contrast-user-name USER_NAME", "Contrast user name" do |contrast_user_name|
+          options[:contrast_user_name] = contrast_user_name
+        end
+        opts.on "--contrast-app-name APP_NAME", "Contrast app name" do |contrast_app_name|
+          options[:contrast_app_name] = contrast_app_name
+        end
+        opts.on "--contrast-update-closed-jira-issues APP_NAME", "Only update Contrast status for closed JIRA issues?" do |contrast_update_closed_jira_issues|
+          options[:contrast_update_closed_jira_issues] = true
         end
 
 

--- a/lib/glue/reporters.rb
+++ b/lib/glue/reporters.rb
@@ -26,7 +26,8 @@ class Glue::Reporters
   def self.run_report(tracker)
     @reporters.each do |c|
       reporter = c.new()
-      if tracker.options[:output_format].first == reporter.format
+
+      if tracker.options[:output_format].include?(reporter.format)
         begin
           output = reporter.run_report(tracker)
           if tracker.options[:output_file]

--- a/lib/glue/reporters/jira_reporter.rb
+++ b/lib/glue/reporters/jira_reporter.rb
@@ -36,7 +36,7 @@ class Glue::JiraReporter < Glue::BaseReporter
     tracker.findings.each do |finding|
       begin
         issue = @jira.Issue.build
-        json = get_jira_json finding
+        json = get_jira_json(finding, tracker.options[:jira_skip_fields] || '')
         issue.save(json)
       rescue Exception => e
         puts "Issue #{e.message}"
@@ -46,7 +46,7 @@ class Glue::JiraReporter < Glue::BaseReporter
   end
 
   private
-  def get_jira_json(finding)
+  def get_jira_json(finding, skip_fields)
 	  json = {
     	"fields": {
        		"project":
@@ -55,13 +55,50 @@ class Glue::JiraReporter < Glue::BaseReporter
        		},
        		"summary": "#{finding.description}",
        		"description": "#{finding.to_string}",
+          "priority": {
+            'name': jira_priority(finding.severity)
+          },
        		"issuetype": {
           		"name": "Bug"
-       		},
-       		"labels":["Glue","#{finding.appname}"]
+       		},       		
        		#{}"components": [ { "name": "#{@component}" } ]
        	}
 	    }
+
+    json['labels'] = [ "Glue", "#{finding.appname}" ] unless skip_fields.split(',').include?('labels')
     json
+  end
+
+  def jira_priority(severity)
+    if is_number?(severity)
+      f = Float(severity)
+
+      if f < 5
+        'Low'
+      elsif f < 7
+        'Medium'
+      else
+        'High'
+      end
+    else
+      case severity
+      when 'HIGH' then 'High'
+      when 'High' then 'High'
+      when 'MEDIUM' then 'Medium'
+      when 'Medium' then 'Medium'
+      when 'NOTE' then 'Low'
+      when 'Note' then 'Low'
+      when 'Low' then 'Low'
+      when 'Information' then 'Low'
+      else
+        Glue.notify "**** Unknown severity type #{severity}"
+        
+        severity
+      end
+    end
+  end
+
+  def is_number?(str)
+    true if Float(str) rescue false
   end
 end

--- a/lib/glue/tasks/contrast.rb
+++ b/lib/glue/tasks/contrast.rb
@@ -1,0 +1,244 @@
+require 'glue/tasks/base_task'
+require 'glue/util'
+require 'httparty'
+
+class Glue::Contrast < Glue::BaseTask
+  Glue::Tasks.add self
+  include Glue::Util
+
+  CLOSED_STATUSES = [ 'Remediated', 'Not a Problem' ]
+
+  def initialize(trigger, tracker)
+    super(trigger, tracker)
+    @name = "Contrast Security"
+    @description = "Retrieves findings from Contrast Security"
+    @stage = :code
+    @labels << "code" << "java" << ".net"
+
+
+    @api_key = @tracker.options[:contrast_api_key]
+    @service_key = @tracker.options[:contrast_service_key]
+    @org_id = @tracker.options[:contrast_org_id]
+    @app_name = @tracker.options[:contrast_app_name]
+    @user_name = @tracker.options[:contrast_user_name]  
+  end
+
+  def run
+    Glue.notify "#{@name}"
+    
+    if @tracker.options[:contrast_update_closed_jira_issues]
+      puts "Updating closed JIRA issues"
+      app_id = contrast_app_id(@app_name)
+      update_closed_jira_issues(app_id)
+    else
+      puts "Running Contrast process"
+      app_id = contrast_app_id(@app_name)
+      traces = contrast_traces(app_id)
+  
+      contrast_vulnerable_libraries(app_id).each do |lib|
+        report_vulnerable_lib(app_id, lib)
+      end
+
+      contrast_stale_libraries(app_id).each do |lib|
+        report_stale_lib(app_id, lib)
+      end
+
+      traces.each do |trace|
+        report_trace(app_id, trace)
+      end
+    end 
+  end
+
+  def update_closed_jira_issues(app_id)
+    issues = get_closed_jira_issues
+
+    issues.each do |iss|
+      contrast_id = contrast_id_for_issue(iss)
+      trace = contrast_trace_details(app_id, contrast_id)
+
+      update_trace(app_id, trace, contrast_resolution_status(iss)) unless CLOSED_STATUSES.include?(trace['status'])
+    end
+  end
+
+  def get_closed_jira_issues
+    initialize_jira
+
+    @jira.Issue.jql("project=#{@project} AND description ~ 'contrastsecurity*' AND resolution IS NOT EMPTY AND resolutiondate > -3d", 
+                      { fields: nil, start_at: nil, max_results: 1000, expand: nil, validate_query: true })
+  end
+
+  def initialize_jira
+    options = {
+      :username     => @tracker.options[:jira_username],
+      :password     => @tracker.options[:jira_password],
+      :site         => @tracker.options[:jira_api_url],
+      :context_path => @tracker.options[:jira_api_context],
+      :auth_type    => :basic,
+      :http_debug   => :true
+    }
+    @project = @tracker.options[:jira_project]
+    @component = @tracker.options[:jira_component]
+    @jira = JIRA::Client.new(options)
+  end
+
+  def contrast_id_for_issue(iss)
+    return '' if iss.description.blank?
+
+    fingerprints = iss.description.scan(/Fingerprint\:\s*(.*)$/)
+    return '' if fingerprints.empty?
+
+    print = fingerprints.first
+    return '' if print.blank?
+
+    print = print.first if print.is_a?(Array)
+
+    print.strip
+  end
+
+  def contrast_resolution_status(iss)
+    return '' if iss.resolution.blank?
+    
+    res_name = iss.resolution['name']
+    return '' if res_name.blank?
+
+    # Possible resolution values (YMMV)
+    # ["Fixed", "Won't Fix", "Duplicate", "Incomplete", "Cannot Reproduce", "Done", "Won't Do", "Cancelled", "Complete"]
+    case res_name
+    when 'Fixed', 'Done', 'Complete', 'Cancelled'
+      'Remediated'
+    when "Won't Fix", "Won't Do", 'Declined', 'Duplicate'
+      'Not a Problem'
+    else
+      ''
+    end
+  end
+
+  def report_stale_lib(app_id, lib)
+    # report description, detail, source, severity, fingerprint
+    self.report "#{lib['file_name']} is out of date.", 
+        "Project uses version #{lib['file_version']}, latest version is #{lib['latest_version']}. #{contrast_library_html_url(app_id, lib['hash'])}",
+        lib['file_name'],
+        'NOTE',
+        lib['hash']
+  end
+
+  def report_vulnerable_lib(app_id, lib)
+    vuln_count = lib['total_vulnerabilities']
+    self.report "#{lib['file_name']} has #{vuln_count} known security #{vuln_count > 1 ? 'vulnerabilities' : 'vulnerability'}.",
+        "#{lib['file_name']} is currently rated #{lib['grade']}. #{contrast_library_html_url(app_id, lib['hash'])}",
+        lib['file_name'],
+        'High',
+        lib['hash']
+  end
+
+  def report_trace(app_id, trace)
+    self.report trace['title'], contrast_trace_html_url(app_id, trace['uuid']), trace['uuid'], trace['severity'], trace['uuid']
+  end
+
+  def contrast_vulnerable_libraries(app_id)
+    contrast_libraries_filtered(app_id, 'VULNERABLE')
+  end
+
+  def contrast_stale_libraries(app_id)
+    contrast_libraries_filtered(app_id, 'STALE')
+  end
+
+  def contrast_libraries_filtered(app_id, filter)
+    url = "#{contrast_base_url}/applications/#{app_id}/libraries/filter?quickFilter=#{filter}"
+    response = HTTParty.get(url, :headers => contrast_request_headers)
+    response['libraries']
+  end
+
+  def contrast_app_id(app_name)
+    function_url = 'applications/filter?sort=appName'
+    url = "#{contrast_base_url}/#{function_url}"
+    
+    response = HTTParty.get(url, :headers => contrast_request_headers)
+    app = response['applications'].detect { |x| x['name'] == app_name }
+
+    app['app_id']
+  end
+
+  def contrast_traces(app_id)
+    trace_ids = contrast_app_trace_ids(app_id)
+    return [ ] if trace_ids.nil?
+
+    res = [ ]
+    trace_ids.each do |trace_id|
+        res << contrast_trace_details(app_id, trace_id)
+    end
+
+    res
+  end
+
+  def contrast_app_trace_ids(app_id)
+    trace_ids_url = "#{contrast_base_url}/traces/#{app_id}/ids"
+    
+    response = HTTParty.get(trace_ids_url, :headers => contrast_request_headers)
+
+    response['traces']
+  end
+
+  def contrast_trace_details(app_id, trace_id)
+    trace_url = "#{contrast_base_url}/traces/#{app_id}/trace/#{trace_id}"
+    response = HTTParty.get(trace_url, :headers => contrast_request_headers)
+
+    response['trace']
+  end
+
+  def update_trace(app_id, trace, status = 'Remediated')
+    payload = {
+      'comment_preference' => true,
+      'note' => '',
+      'status' => status,
+      'substatus' => '',
+      'traces' => [ trace['uuid'] ]
+    }
+    
+    mark_trace_url = "#{contrast_base_url}/traces/#{app_id}/mark"
+
+    puts ">>> Updating trace #{trace['uuid']}"
+    response = HTTParty.put(mark_trace_url, 
+                            :headers => contrast_request_headers,
+                            :body => payload.to_json)
+  end
+
+  def contrast_trace_html_url(app_id, trace_id)
+    "https://app.contrastsecurity.com/Contrast/static/ng/index.html#/#{@org_id}/applications/#{app_id}/vulns/#{trace_id}"
+  end
+
+  def contrast_library_html_url(app_id, lib_hash)
+    "https://app.contrastsecurity.com/Contrast/static/ng/index.html#/#{@org_id}/applications/#{app_id}/libs/java/#{lib_hash}"
+  end
+
+  def contrast_request_headers
+    { 'API-Key' => @api_key, 'Authorization' => Base64.urlsafe_encode64("#{@user_name}:#{@service_key}"), 
+      'Accept' => 'application/json', 'Content-Type' => 'application/json' }
+  end
+
+  def contrast_base_url
+    "https://app.contrastsecurity.com/Contrast/api/ng/#{@org_id}"
+  end
+
+  def analyze
+    path = @trigger.path + "/dependency-check-report.xml"
+    begin
+      Glue.debug "Parsing report #{path}"
+      get_warnings(path)
+    rescue Exception => e
+      Glue.notify "Problem running OWASP Dep Check ... skipped."
+      Glue.notify e.message
+      raise e
+    end
+  end
+
+  def supported?
+    true
+  end
+
+  def get_warnings(path)
+    listener = Glue::DepCheckListener.new(self)
+    parser = Parsers::StreamParser.new(File.new(path), listener)
+    parser.parse
+  end
+end


### PR DESCRIPTION
Big item:

- Added a task for Contrast Security. This is useful for extracting vulnerability data from Contrast via its API. This task also knows how to update Contrast vulnerabilities when corresponding JIRA issues are closed.

Smaller items:

- Added option to skip specific JIRA fields
- Added support for multiple output formats.
