### PR TITLE
Making glue threadsafe

### DIFF
--- a/glue.gemspec
+++ b/glue.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "dawnscanner", ">= 1.6.0"
   s.add_dependency "redcarpet"
   s.add_dependency "jira-ruby"
+  s.add_dependency "httparty"
 
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-byebug"

--- a/lib/glue/tasks/bundle-audit.rb
+++ b/lib/glue/tasks/bundle-audit.rb
@@ -19,9 +19,7 @@ class Glue::BundleAudit < Glue::BaseTask
   def run
     directories_with?('Gemfile.lock').each do |dir|
       Glue.notify "#{@name} scanning: #{dir}"
-      Dir.chdir(dir) do
-        @results[dir] = runsystem(true, "bundle-audit", "check")
-      end
+      @results[dir] = runsystem(true, "bundle-audit", "check", :chdir => dir)
     end
   end
 

--- a/lib/glue/tasks/dawnscanner.rb
+++ b/lib/glue/tasks/dawnscanner.rb
@@ -16,11 +16,9 @@ class Glue::DawnScanner < Glue::BaseTask
   end
 
   def run
-    Dir.chdir("#{@trigger.path}") do
-      @results_file = Tempfile.new(['dawnresults', 'xml'])
-      runsystem(true, "dawn", "-F", "#{@results_file.path}", "-j", ".")
-      @results = JSON.parse(File.read("#{@results_file.path}"))['vulnerabilities']
-    end
+    @results_file = Tempfile.new(['dawnresults', 'xml'])
+    runsystem(true, "dawn", "-F", "#{@results_file.path}", "-j", ".", :chdir => @trigger.path)
+    @results = JSON.parse(File.read("#{@results_file.path}"))['vulnerabilities']
   end
 
   def analyze

--- a/lib/glue/tasks/npm.rb
+++ b/lib/glue/tasks/npm.rb
@@ -22,15 +22,13 @@ class Glue::Npm < Glue::BaseTask
     exclude_dirs = exclude_dirs.concat(@tracker.options[:exclude_dirs]).uniq if @tracker.options[:exclude_dirs]
     directories_with?('package.json', exclude_dirs).each do |dir|
       Glue.notify "#{@name} scanning: #{dir}"
-      Dir.chdir(dir) do
-        if @tracker.options.has_key?(:npm_registry)
-          registry = "--registry #{@tracker.options[:npm_registry]}"
-        else
-          registry = nil
-        end
-        @command = "npm install -q --ignore-scripts #{registry}"
-        @results << runsystem(true, @command)
+      if @tracker.options.has_key?(:npm_registry)
+        registry = "--registry #{@tracker.options[:npm_registry]}"
+      else
+        registry = nil
       end
+      @command = "npm install -q --ignore-scripts #{registry}"
+      @results << runsystem(true, @command, :chdir => dir)
     end
   end
 

--- a/lib/glue/tasks/nsp.rb
+++ b/lib/glue/tasks/nsp.rb
@@ -20,10 +20,8 @@ class Glue::NodeSecurityProject < Glue::BaseTask
     exclude_dirs = exclude_dirs.concat(@tracker.options[:exclude_dirs]).uniq if @tracker.options[:exclude_dirs]
     directories_with?('package.json', exclude_dirs).each do |dir|
       Glue.notify "#{@name} scanning: #{dir}"
-      Dir.chdir(dir) do
-        res = runsystem(true, "nsp", "check", "--output", "json")
-        @results << JSON.parse(res)
-      end
+      res = runsystem(true, "nsp", "check", "--output", "json", :chdir => dir)
+      @results << JSON.parse(res)
     end
   end
 

--- a/lib/glue/tasks/pmd.rb
+++ b/lib/glue/tasks/pmd.rb
@@ -18,9 +18,8 @@ class Glue::PMD < Glue::BaseTask
 
   def run
     @tracker.options[:pmd_checks] ||= "java-basic,java-sunsecure"
-    Dir.chdir @tracker.options[:pmd_path] do
-      @results = Nokogiri::XML(runsystem(true,'bin/run.sh', 'pmd', '-d', "#{@trigger.path}", '-f', 'xml', '-R', "#{@tracker.options[:pmd_checks]}")).xpath('//file')
-    end
+    results_xml = runsystem(true,'bin/run.sh', 'pmd', '-d', "#{@trigger.path}", '-f', 'xml', '-R', "#{@tracker.options[:pmd_checks]}", :chdir => @tracker.options[:pmd_path])
+    @results = Nokogiri::XML(results_xml).xpath('//file')
   end
 
   def analyze

--- a/lib/glue/tasks/test.rb
+++ b/lib/glue/tasks/test.rb
@@ -17,9 +17,7 @@ class Glue::Test < Glue::BaseTask
     # Glue.notify "#{@name}"
     rootpath = @trigger.path
     Glue.debug "Rootpath: #{rootpath}"
-    Dir.chdir("#{rootpath}") do
-      @result= runsystem(true, "grep", "-R", "secret")
-    end
+    @result= runsystem(true, "grep", "-R", "secret", :chdir => rootpath)
   end
 
   def analyze

--- a/lib/glue/util.rb
+++ b/lib/glue/util.rb
@@ -1,18 +1,15 @@
 require 'open3'
 require 'pathname'
 require 'digest'
-require 'pry'
 
 module Glue::Util
 
   def runsystem(report, *splat)
     Open3.popen3(*splat) do |stdin, stdout, stderr, wait_thr|
 
-      Thread.new do
-        if $logfile and report
-          while line = stderr.gets do
-            $logfile.puts line
-          end
+      if $logfile and report
+        while line = stderr.gets do
+          $logfile.puts line
         end
       end
 

--- a/lib/glue/version.rb
+++ b/lib/glue/version.rb
@@ -1,3 +1,3 @@
 module Glue
-  Version = "0.9.1"
+  Version = "0.9.2"
 end


### PR DESCRIPTION
Dir.chdir() isn't threadsafe as it changes the cwd for the parent process.  I replaced it globally with the chdir splat functionality from System.spawn (used by Open3.popen3 for the runsystem() call).