### PR TITLE
severity_threshold

### DIFF
--- a/bin/glue
+++ b/bin/glue
@@ -56,10 +56,20 @@ end
 begin
     #Run scan and output a report
     tracker = Glue.run options.merge(:print_report => true, :quiet => options[:quiet])
+    worst_finding = tracker.get_worst_finding
 
     #Return error code if --exit-on-warn is used and warnings were found
     if options[:exit_on_warn] and not tracker.findings.empty?
-      exit Glue::Warnings_Found_Exit_Code
+      if options[:severity_threshold]
+        if worst_finding.severity >= options[:severity_threshold].to_i
+          puts "Worst finding (#{worst_finding.severity}) meets severity threshold (#{options[:severity_threshold]})"
+          exit worst_finding.severity
+        else
+          puts "Worst finding (#{worst_finding.severity}) did not meet severity threshold (#{options[:severity_threshold]})"
+        end
+      else
+        exit Glue::Warnings_Found_Exit_Code
+      end
     end
 rescue Glue::NoTargetError => e
   $stderr.puts e.message

--- a/lib/glue/options.rb
+++ b/lib/glue/options.rb
@@ -45,9 +45,16 @@ module Glue::Options
           options[:quiet] = quiet
         end
 
-        opts.on( "-z", "--exit-on-warn", "Exit code is non-zero if warnings found") do
+        opts.on( "-z", "--exit-on-warn [severity_threshold]", "Exit code is non-zero if warnings found. If [severity_threshold] is specified, the highest severity must be greater than or equal to [severity_threshold] to tigger the non-zero exit code, which will equal the highest severity.") do |severity_threshold|
           options[:exit_on_warn] = true
+          if severity_threshold
+            puts "Setting severity_threshold to #{severity_threshold}"
+            
+          end
+          options[:severity_threshold] = severity_threshold
         end
+
+  
 
         opts.separator ""
         opts.separator "Scanning options:"

--- a/lib/glue/tasks/zap.rb
+++ b/lib/glue/tasks/zap.rb
@@ -24,6 +24,7 @@ class Glue::Zap < Glue::BaseTask
     context = SecureRandom.uuid
 
     Glue.debug "Running ZAP on: #{rootpath} from #{base} with #{context}"
+    puts "Running ZAP on: #{rootpath} from #{base} with #{context}"
 
     # Create a new session so that the findings will be new.
     Curl.get("#{base}/JSON/core/action/newSession/?zapapiformat=JSON&apikey=#{apikey}&name=&overwrite=")
@@ -86,9 +87,16 @@ class Glue::Zap < Glue::BaseTask
   end
 
   def supported?
+    apikey = "#{@tracker.options[:zap_api_token]}"
     base = "#{@tracker.options[:zap_host]}:#{@tracker.options[:zap_port]}"
-    supported=JSON.parse(Curl.get("#{base}/JSON/core/view/version/").body_str)
-    if supported["version"] =~ /2.(4|5).\d+/
+    
+    begin
+      supported=JSON.parse(Curl.get("#{base}/JSON/core/view/version/?apikey=#{apikey}").body_str)
+    rescue Exception => e
+      Glue.error "#{e.message}. Tried to connect to #{base}/JSON/core/view/version/. Check that ZAP is running on the right host and port and that you have the appropriate API key, if required."
+      return false
+    end
+    if supported["version"] =~ /2.(4|5|6).\d+/
       return true
     else
       Glue.notify "Install ZAP from owasp.org and ensure that the configuration to connect is correct.  Supported versions = 2.4.0 and up - got #{supported['version']}"

--- a/lib/glue/tracker.rb
+++ b/lib/glue/tracker.rb
@@ -33,6 +33,18 @@ class Glue::Tracker
     @findings << finding
   end
 
+  def get_worst_finding
+    worst = nil
+    @findings.each do |finding|
+      if !worst
+        worst = finding
+      elsif finding.severity > worst.severity
+        worst = finding
+      end
+    end
+    worst
+  end
+
   def to_json
     s = "{ \"findings\": [ "
     @findings.each do |finding|


### PR DESCRIPTION
Add a severity_threshold for the -z option. If set, only if a finding
has a severity that meets or exceeds the threshold will Glue return an
error code (equal to the highest severity).