### PR TITLE
Added Slack reporter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gem "rake"
 gem "rspec"
 gem 'aruba', '~> 0.14.2'
 gem 'httparty'
+gem 'slack-ruby-client'

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -94,10 +94,20 @@ The alternatives are:
 2.  text (default)
 3.  json
 4.  jira (must specify JIRA options)
+5.  slack (must specify SLACK options)
 
 Generally, it is advised to run Glue with the options you want to try
 and get the output in text or one of the other local formats (json, csv)
-prior to pushing to JIRA.
+prior to pushing to JIRA/Slack.
+
+### Slack Configurations
+The Slack reporters send the finding in one message to a given channel. 
+In order to be able to report to slack, you need first to create a new [Slack Bot](https://my.slack.com/services/new/bot).
+After creating the bot, copy the API token and pass it to glue using the `--slack-token` parameter.
+You can control the channel using the `--slack-channel` parameter - can be either channel name or user name.
+Please note that in order to post to channel, you first has to add the bot you created to this channel.
+When posting to a user instead to a channel, you can configure the behavior using the `--slack-post-as-bot` flag.
+See the documentation [here](https://api.slack.com/methods/chat.postMessage#channels) for details.
 
 ## Configuration Files
 

--- a/lib/glue.rb
+++ b/lib/glue.rb
@@ -163,6 +163,8 @@ module Glue
       [:to_jira]
     when :pivotal, :to_pivotal
       [:to_pivotal]
+    when :slack
+      [:to_slack]
     else
       [:to_s]
     end

--- a/lib/glue/options.rb
+++ b/lib/glue/options.rb
@@ -107,7 +107,7 @@ module Glue::Options
         end
         opts.on "-f",
                 "--format TYPE",
-                [:text, :csv, :json, :jira, :pivotal],
+                [:text, :csv, :json, :jira, :pivotal, :slack],
                 "Specify output formats. Default is text" do |type|
           options[:output_format] = type
         end
@@ -289,6 +289,19 @@ module Glue::Options
         end
 
         opts.separator ""
+        opts.separator "Slack reporter options:"
+        opts.on "--slack-token TOKEN", "Bot token" do |slack_token|
+          options[:slack_token] = slack_token
+        end
+        opts.on "--slack-channel CHANNEL", "The channel/user to post to" do |slack_channel|
+          options[:slack_channel] = slack_channel
+        end
+        opts.on "--slack-post-as-bot", "When posting to user, set this flag to post on the bot channel for this users",
+        "Otherwise, the bot will post to the user's slackbot." do |slack_post_as_user|
+          options[:slack_post_as_user] = slack_post_as_user
+        end
+
+        opts.separator ""
         opts.separator "Configuration files:"
 
         opts.on "-c", "--config-file FILE", "Use specified configuration file" do |file|
@@ -302,6 +315,7 @@ module Glue::Options
             options[:create_config] = true
           end
         end
+        
 
         opts.separator ""
         opts.separator "Other Useful Options:"

--- a/lib/glue/reporters/slack_reporter.rb
+++ b/lib/glue/reporters/slack_reporter.rb
@@ -1,0 +1,54 @@
+require 'glue/finding'
+require 'glue/reporters/base_reporter'
+require 'jira-ruby'
+require 'slack-ruby-client'
+
+class Glue::SlackReporter < Glue::BaseReporter
+  Glue::Reporters.add self
+
+  attr_accessor :name, :format
+
+  def initialize()
+    @name = "SlackReporter"
+    @format = :to_slack
+  end
+
+  def run_report(tracker)
+    post_as_user = false
+    if (tracker.options[:slack_post_as_user])
+      post_as_user = true
+    end
+
+    mandatory = [:slack_token, :slack_channel]   
+    missing = mandatory.select{ |param| tracker.options[param].nil? }     
+    unless missing.empty?                                           
+      Glue.fatal "missing one or more required params: #{missing}"
+      return
+    end  
+
+    Slack.configure do |config|
+        config.token = tracker.options[:slack_token]
+    end
+
+    client = Slack::Web::Client.new
+    
+    begin
+      client.auth_test
+    rescue Slack::Web::Api::Error => error
+      Glue.fatal "Slack authentication failed: " << error.to_s
+    end
+
+    reports = []
+    tracker.findings.each do |finding|
+      reports << finding.to_string
+    end
+
+    puts tracker.options[:slack_channel]
+
+    begin
+      client.chat_postMessage(channel: tracker.options[:slack_channel], text: reports.join << "\n", as_user: post_as_user)
+    rescue Slack::Web::Api::Error => error
+      Glue.fatal "Post to slack failed: " << error.to_s
+    end
+  end
+end


### PR DESCRIPTION
I need some help with testing - I want to write unit tests for this reporter, but I am not sure how to mock the Slack client. Look like the best option is to be able to inject it somehow (I was looking into DI for ruby, [dry-system](http://dry-rb.org/gems/dry-system/) for example, but it was too complex to integrate it). Another option was to create the client in the constructor:
```ruby
  def initialize(client = nil)
    @name = "SlackReporter"
    @format = :to_slack

    if client.nil?
       @client = Slack::Web::Client.new
    else
       @client = client
    end
  end
```
The problem with that - before creating the client, you have to set the token using one of the configuration methods (see details in the gem [readme](https://github.com/slack-ruby/slack-ruby-client)). As the token is passed only in the `run_report` method (in the `tracker` parameter), it is not available in the constructor.
Could you help me with that? I am not so familiar with Ruby, so I'm probably missing something here...