### PR TITLE
Clean up trufflehog.rb

### DIFF
--- a/lib/glue/tasks/trufflehog.rb
+++ b/lib/glue/tasks/trufflehog.rb
@@ -7,9 +7,6 @@ class Glue::Trufflehog < Glue::BaseTask
   Glue::Tasks.add self
   include Glue::Util
 
-  BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
-  HEX_CHARS = "1234567890abcdefABCDEF"
-
   ISSUE_SEVERITY = 4
 
   def initialize(trigger, tracker)
@@ -27,33 +24,10 @@ class Glue::Trufflehog < Glue::BaseTask
     @result = runsystem(true, '/usr/bin/env', 'python', @trufflehog_path, '--json', @trigger.path)
   end
 
-  def report_stale_lib(app_id, lib)
-    # report description, detail, source, severity, fingerprint
-    self.report "#{lib['file_name']} is out of date.", 
-        "Project uses version #{lib['file_version']}, #{LIB_STALE_CONNECTOR} #{lib['latest_version']}. #{contrast_library_html_url(app_id, lib['hash'])}",
-        lib['file_name'],
-        'NOTE',
-        lib['hash']
-  end
-
-  def report_vulnerable_lib(app_id, lib)
-    vuln_count = lib['total_vulnerabilities']
-    self.report "#{lib['file_name']} has #{vuln_count} known security #{vuln_count > 1 ? 'vulnerabilities' : 'vulnerability'}.",
-        "#{lib['file_name']} #{LIB_RATING_CONNECTOR} #{lib['grade']}. #{contrast_library_html_url(app_id, lib['hash'])}",
-        lib['file_name'],
-        'High',
-        lib['hash']
-  end
-
-  def report_trace(app_id, trace)
-    Glue.debug "Reporting trace with fingerprint #{contrast_trace_html_url(app_id, trace['uuid'])}"
-    self.report trace['title'], contrast_trace_html_url(app_id, trace['uuid']), trace['uuid'], trace['severity'], trace['uuid']
-  end
-
   def analyze
     begin
-      Glue.debug "Parsing results..."
-      puts @result
+      # Glue.debug "Parsing results..."
+      # puts @result
       get_warnings
     rescue Exception => e
       Glue.notify "Problem running Trufflehog ... skipped."
@@ -63,12 +37,18 @@ class Glue::Trufflehog < Glue::BaseTask
   end
 
   def supported?
+    if runsystem(false, '/usr/bin/env', 'python', @trufflehog_path, '-h').empty?
+      Glue.notify "Check that TruffleHog is installed at #{@trufflehog_path}."
+      return false
+    end
+
     true
   end
 
+  private
+
   def get_warnings
     JSON::parse(@result).each do |title, string|
-      description = "Possible password or other secret at #{title}."
       detail = "Apparent password or other secret: #{string}"
       fingerprint = "Trufflehog|#{title}"
       self.report "Possible password or other secret in source code.", detail, title, ISSUE_SEVERITY, fingerprint


### PR DESCRIPTION
- Delete unused methods and vars:
It seems like 'report_stale_lib', 'report_vulnerable_lib' and 'report_trace'
were copied over from a different task. I don't think they're used in the
context of Trufflehog (I could be wrong though).

- Implement basic functionality for .supported?:
I just check that the python executable runs by having it print out Trufflehog's
help message. This could be made more sophisticated (eg, checking that
the installed executable is up-to-date with the version in runako's repo).

- Make 'get_warnings' private.

Also, I'm not sure about the line ISSUE_SEVERITY = 4.
It doesn't seem like other tasks follow this approach to setting the
security level (and it doesn't seem like '4' is one of the usual levels).
I just left it as-is.