### PR TITLE
Refactor sfl.rb

### DIFF
--- a/lib/glue/tasks/sfl.rb
+++ b/lib/glue/tasks/sfl.rb
@@ -1,67 +1,124 @@
 require 'glue/tasks/base_task'
-require 'json'
 require 'glue/util'
+require 'json'
 require 'find'
+require 'English'
 
 class Glue::SFL < Glue::BaseTask
-
   Glue::Tasks.add self
   include Glue::Util
 
+  PATTERNS_FILE_PATH = File.join(File.dirname(__FILE__), "patterns.json")
+
   def initialize(trigger, tracker)
-    super(trigger,tracker)
+    super(trigger, tracker)
     @name = "SFL"
-    @description = "Sentive Files Lookup"
+    @description = "Sensitive File Lookup (SFL)"
     @stage = :code
     @labels << "code"
-    # Glue.debug "initialized SFL"
-    @patterns = read_patterns_file!
+    @results = []
+    self
   end
 
   def run
-    # Glue.notify "#{@name}"
-    @files = Find.find(@trigger.path)
-    Glue.debug "Found #{@files.count} files"
+    begin
+      Glue.notify @name
+      run_sfl!
+    rescue StandardError => e
+      log_error(e)
+    end
+
+    self
   end
 
   def analyze
-    begin
-      @files.each do |file|
-        @patterns.each do |pattern|
-          case pattern['part']
-            when 'filename'
-              if pattern_matched?(File.basename(file), pattern)
-                report pattern['caption'], pattern['description'], @name + ":" + file, 'unknown', 'TBD'
-              end
-            when 'extension'
-              if pattern_matched?(File.extname(file), pattern)
-                report pattern['caption'], pattern['description'], @name + ":" + file, 'unknown', 'TBD'
-              end
-          end
-        end
+    @results.each do |result|
+      begin
+        report_finding! result
+      rescue StandardError => e
+        log_error(e)
       end
-    rescue Exception => e
-      Glue.warn e.message
     end
+
+    self
   end
 
   def supported?
     true
   end
 
-  def pattern_matched?(txt, pattrn)
-    case pattrn['type']
-      when 'match'
-        return txt == pattrn['pattern']
-      when 'regex'
-        regex = Regexp.new(pattrn['pattern'], Regexp::IGNORECASE)
-        return !regex.match(txt).nil?
+  def self.patterns
+    @patterns ||= read_patterns_file
+    @patterns.dup
+  end
+
+  def self.matches?(filepath, pattern)
+    text = extract_filepart(filepath, pattern)
+    pattern_matched?(text, pattern)
+  end
+
+  private
+
+  def run_sfl!
+    files = Find.find(@trigger.path).select { |path| File.file?(path) }
+    Glue.debug "Found #{files.count} files"
+
+    files.each do |filepath|
+      self.class.patterns.each do |pattern|
+        if self.class.matches?(filepath, pattern)
+          @results << { filepath: filepath, pattern: pattern }
+        end
+      end
+    end
+
+    nil
+  end
+
+  def report_finding!(result)
+    pattern = result[:pattern]
+    filepath = result[:filepath]
+
+    description = pattern['caption']
+    detail = pattern['description']
+    source = "#{@name}:#{filepath}"
+    severity = 'unknown'
+    fprint = fingerprint("SFL-#{pattern['part']}#{pattern['type']}" \
+                          "#{pattern['pattern']}#{filepath}")
+
+    report description, detail, source, severity, fprint
+  end
+
+  private_class_method def self.read_patterns_file
+    JSON.parse(File.read(PATTERNS_FILE_PATH))
+  rescue
+    modified_message = "#{$ERROR_INFO} (problem with SFL patterns file)"
+    raise $ERROR_INFO, modified_message, $ERROR_INFO.backtrace
+  end
+
+  private_class_method def self.extract_filepart(filepath, pattern)
+    case pattern['part']
+    when 'filename'   then File.basename(filepath)
+    when 'extension'  then File.extname(filepath).gsub(/^\./, '')
+    when 'path'       then filepath
+    else ''
     end
   end
 
-  def read_patterns_file!
-    JSON.parse(File.read("#{File.dirname(__FILE__)}/patterns.json"))
-  rescue JSON::ParserError => e
-    Glue.warn "Cannot parse pattern file: #{e.message}"
+  private_class_method def self.pattern_matched?(text, pattern)
+    case pattern['type']
+    when 'match'
+      text == pattern['pattern']
+    when 'regex'
+      regex = Regexp.new(pattern['pattern'], Regexp::IGNORECASE)
+      !!regex.match(text)
+    else
+      false
+    end
+  end
+
+  def log_error(e)
+    Glue.notify "Problem running SFL"
+    Glue.warn e.inspect
+    Glue.warn e.backtrace
   end
 end


### PR DESCRIPTION
- Refactor run/analyze to mimic the non-built-in tasks:
  - 'run' appends each raw finding to '@results'
  - 'analyze' converts the '@results' to Findings
  - implementation moved to private methods
- Add exception handling
- Cache the 'patterns' at the class-level
- In 'run':
  - Only run sfl on files (not dirs too)
  - Add support for the case pattern['part'] = 'path'
  - Fix an error in the case pattern['part'] = 'extension'
- In 'analyze':
  - Implement a unique fingerprint
- The 'English' module allows '$ERROR_INFO' instead of '$!'

Note that the 'severity' is still set to 'unknown'. I'm not sure how best to
handle that. One way would be to add a severity level to every pattern
in patterns.json, but that would break parity with the original json file
on which patterns.json was based (from gitrob), which might make it more
difficult to update patterns.json.  (Also, it might make sense to rename it
to 'sfl_patterns.json'.)