### PR TITLE
Refactor retirejs.rb

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -19,10 +19,10 @@ glue --checks
 
 In most of the examples provided for running Glue, we specify the CLI like:
 ```
-glue operation target.  
+glue operation target.
 ```
 
-The target can be:  
+The target can be:
 1.  A git repository eg:  https://github.com/jemurai/triage.git
 2.  A local directory (/tmp/hello)
 3.  A url (for live tools)
@@ -108,7 +108,7 @@ Optional parameters:
 * `--checkmarx-path`: The path to the CxCli folder.
 * `--checkmarx-log`: Log file for the scans
 
-See [CxConsole](https://checkmarx.atlassian.net/wiki/display/KC/-CxConsole%3A+CxSAST+CLI) documentation for more details about those options. 
+See [CxConsole](https://checkmarx.atlassian.net/wiki/display/KC/-CxConsole%3A+CxSAST+CLI) documentation for more details about those options.
 Not all options are currently supported - if you noticed a missing option you need, feel free to add.
 
 An example scan:
@@ -150,7 +150,7 @@ glue -t nsp target
 ### Retire.js
 
 ```
-npm install -g retirejs
+npm install -g retire
 ```
 
 Retire.js is a node library for checking dependencies for known vulnerabilities.
@@ -243,7 +243,7 @@ In this section we will report the relative maturity of the tools and integratio
 
 The grades are common academic grades:  A is excellent, B is ok, C is meh, F is failing.
 
-The areas we'll talk about include:  
+The areas we'll talk about include:
 1.  Integration - How well the tool is integrated into Glue right now.
 2.  Tool Value - Our take on how valuable the tool is.
 3.  Focus:  Any specifics areound where the tool focuses.

--- a/lib/glue/tasks/retirejs.rb
+++ b/lib/glue/tasks/retirejs.rb
@@ -1,107 +1,213 @@
 require 'glue/tasks/base_task'
-require 'json'
 require 'glue/util'
+require 'json'
 require 'jsonpath'
-require 'pathname'
-require 'pry'
 
 class Glue::RetireJS < Glue::BaseTask
-
   Glue::Tasks.add self
   include Glue::Util
 
+  SUPPORTED_CHECK_STR = 'retire --help'.freeze
+  BASE_EXCLUDE_DIRS = %w[node_modules bower_components].freeze
+
   def initialize(trigger, tracker)
     super(trigger, tracker)
-    @name = "RetireJS"
-    @description = "Dependency analysis for JavaScript"
+    @name = 'RetireJS'
+    @description = 'Dependency analysis for JavaScript'
     @stage = :code
-    @labels << "code" << "javascript"
+    @labels << 'code' << 'javascript'
     @results = []
   end
 
   def run
-    exclude_dirs = ['node_modules','bower_components']
-    exclude_dirs = exclude_dirs.concat(@tracker.options[:exclude_dirs]).uniq if @tracker.options[:exclude_dirs]
     directories_with?('package.json', exclude_dirs).each do |dir|
       Glue.notify "#{@name} scanning: #{dir}"
-      @results << runsystem(false, 'retire', '-c', '--outputformat', 'json', '--path', "#{dir}")
+      command_line = 'retire -c --outputpath /dev/stdout ' \
+        "--outputformat json --path #{dir}"
+      raw_output = runsystem(true, command_line)
+      @results << raw_output
     end
+
+    self
   end
 
   def analyze
-    begin
-      @results.each do |result|
-        parsed_json = JSON.parse(result)
-        vulnerabilities = parse_retire_json(parsed_json) if parsed_json
+    # Each element of @results is a string (the output of 'retire')
+    # representing all results for a given package.json directory.
 
-        vulnerabilities.each do |vuln|
-          report "Package #{vuln[:package]} has known security issues", vuln[:detail], vuln[:source], vuln[:severity], fingerprint("#{vuln[:package]}#{vuln[:source]}#{vuln[:severity]}")
-        end
-      end
-    rescue JSON::ParserError => e
-      Glue.debug e.message
-    rescue Exception => e
-      Glue.warn e.message
-      Glue.warn e.backtrace
-    end
-  end
-
-  def parse_retire_json result
-    Glue.debug "Retire JSON Raw Result:  #{result}"
-    vulnerabilities = []
-    # This is very ugly, but so is the json retire.js spits out
-    # Loop through each component/version combo and pull all results for it
-    JsonPath.on(result, '$..component').uniq.each do |comp|
-      JsonPath.on(result, "$..results[?(@.component == \'#{comp}\')].version").uniq.each do |version|
-        vuln_hash = {}
-        vuln_hash[:package] = "#{comp}-#{version}"
-
-        version_results = JsonPath.on(result, "$..results[?(@.component == \'#{comp}\')]").select { |r| r['version'] == version }.uniq
-
-        # If we see the parent-->component relationship, dig through the dependency tree to try and make a dep map
-        deps = []
-        obj = version_results[0]
-        while !obj['parent'].nil?
-          deps << obj['parent']['component']
-          obj = obj['parent']
-        end
-        if deps.length > 0
-          vuln_hash[:source] = { :scanner => @name, :file => "#{deps.reverse.join('->')}->#{comp}-#{version}", :line => nil, :code => nil }
-        end
-
-        vuln_hash[:severity] = 'unknown'
-        # pull detail/severity
-        version_results.each do |version_result|
-          JsonPath.on(version_result, '$..vulnerabilities').uniq.each do |vuln|
-            vuln_hash[:severity] = severity(vuln[0]['severity'])
-            vuln_hash[:detail] = vuln[0]['info'].join('\n')
-          end
-        end
-
-        vulnerabilities << vuln_hash
+    @results.each do |raw_results|
+      begin
+        vulnerabilities = parse_retire_results(raw_results)
+        report_findings!(vulnerabilities)
+      rescue StandardError => e
+        log_error(e)
       end
     end
 
-    # Loop through the separately reported 'file' findings so we can tag the source (no dep map here)
-    result.select { |r| !r['file'].nil? }.each do |file_result|
-      JsonPath.on(file_result, '$..component').uniq.each do |comp|
-        JsonPath.on(file_result, "$..results[?(@.component == \'#{comp}\')].version").uniq.each do |version|
-          source_path = relative_path(file_result['file'], @trigger.path)
-          vulnerabilities.select { |v| v[:package] == "#{comp}-#{version}" }.first[:source] = { :scanner => @name, :file => source_path.to_s, :line => nil, :code => nil }
-        end
-      end
-    end
-    return vulnerabilities
+    self
   end
 
   def supported?
-    supported=runsystem(false, "retire", "--help")
-    if supported =~ /command not found/
-      Glue.notify "Install RetireJS"
-      return false
-    else
-      return true
+    runsystem(false, supported_check_str)
+    true
+  rescue Errno::ENOENT # gets raised if the command isn't found
+    Glue.notify "Install RetireJS: 'npm install -g retire'"
+    false
+  end
+
+  private
+
+  def exclude_dirs
+    extra_exclude_dirs = @tracker.options[:exclude_dirs] || []
+    BASE_EXCLUDE_DIRS | extra_exclude_dirs
+  end
+
+  def supported_check_str
+    # The main purpose of this method is to allow stubbing
+    # the 'supported_check_str' in the spec tests, without modifying
+    # the SUPPORTED_CHECK_STR itself.
+    SUPPORTED_CHECK_STR
+  end
+
+  def report_findings!(vulnerabilities)
+    vulnerabilities.each do |vuln|
+      description = "#{vuln[:package]} has known security issues"
+      detail = vuln[:detail]
+      source = vuln[:source]
+      sev = vuln[:severity]
+      fprint = fingerprint("#{vuln[:package]}#{source}#{sev}#{detail}")
+
+      report description, detail, source, sev, fprint
     end
   end
 
+  def parse_retire_results(raw_results)
+    all_results = JSON.parse(raw_results)
+    Glue.debug "Retire JSON Raw Results:  #{all_results}"
+
+    return [] if all_results.nil?
+
+    js_results, npm_results = all_results.partition do |result|
+      result.key?('file')
+    end
+
+    js_vulnerabilities(js_results) + npm_vulnerabilities(npm_results)
+  end
+
+  def js_vulnerabilities(results)
+    parse_vulnerabilities(results, false)
+  end
+
+  def npm_vulnerabilities(results)
+    parse_vulnerabilities(results, true)
+  end
+
+  def parse_vulnerabilities(results, for_npm)
+    findings = []
+    names_versions = get_name_version_combos(results)
+
+    names_versions.each do |name, version|
+      filtered = filter_results(results, name, version)
+      proto_result = filtered.first
+
+      source_tag = if for_npm
+                     npm_dependency_maps(filtered)
+                   else
+                     js_vuln_filenames(results, name, version)
+                   end
+
+      curr_findings = vulnerability_hashes(proto_result, source_tag)
+      findings.concat(curr_findings)
+    end
+
+    findings
+  end
+
+  def get_name_version_combos(results)
+    name_version_combos = []
+    names = JsonPath.on(results, '$..component').uniq
+
+    names.each do |name|
+      versions_filter = "$..results[?(@.component == \'#{name}\')].version"
+      versions = JsonPath.on(results, versions_filter).uniq
+      curr_combos = versions.map { |version| [name, version] }
+      name_version_combos.concat(curr_combos)
+    end
+
+    name_version_combos
+  end
+
+  def filter_results(results, name, version)
+    name_filter = "$..results[?(@.component == \'#{name}\')]"
+    by_name = JsonPath.on(results, name_filter)
+
+    by_name_and_version = by_name.select do |result|
+      result['version'] == version
+    end.uniq
+
+    by_name_and_version
+  end
+
+  def npm_dependency_maps(package_results)
+    maps = []
+
+    package_results.each do |package|
+      deps = []
+      nested_comp = package
+
+      while nested_comp['parent']
+        deps << nested_comp['parent']['component']
+        nested_comp = nested_comp['parent']
+      end
+
+      next if deps.empty?
+
+      package_info = package_tag(package_results.first)
+      map = "#{deps.reverse.join('->')}->#{package_info}"
+      maps << map
+    end
+
+    maps.join("\n")
+  end
+
+  def js_vuln_filenames(js_results, name, version)
+    # Each vuln file has its own js_result hash, with
+    # possibly several diff't js lib vulns. Go through
+    # each file's hash and check if it contains a vuln
+    # related to the supplied name/version.
+
+    js_results.each_with_object([]) do |js_result, filenames|
+      not_relevant = filter_results(js_result, name, version).empty?
+      next if not_relevant
+
+      abs_file_path = js_result['file']
+      abs_dir_path = File.expand_path(@trigger.path)
+      filename = relative_path(abs_file_path, abs_dir_path).to_s
+      filenames << filename
+    end.join("\n")
+  end
+
+  def vulnerability_hashes(proto_result, source_tag)
+    proto_result['vulnerabilities'].each_with_object([]) do |vuln, vulns|
+      vuln_hash = {
+        package: package_tag(proto_result),
+        source: { scanner: @name, file: source_tag, line: nil, code: nil },
+        severity: severity(vuln['severity']),
+        detail: vuln['info'].join("\n")
+      }
+      vulns << vuln_hash
+    end
+  end
+
+  def package_tag(result)
+    name = result['component']
+    version = result['version']
+    "#{name}-#{version}"
+  end
+
+  def log_error(e)
+    Glue.notify 'Problem running RetireJS'
+    Glue.warn e.inspect
+    Glue.warn e.backtrace
+  end
 end


### PR DESCRIPTION
- Fix a typo in TOOLS.md
- Fix a problem in the cli args to 'runsystem'
  * 'retire' sends its output to STDERR by default
  * needed to redirect it to STDOUT for Glue to pick it up
- Fix the 'supported?' method
  * If an uninstalled tool is called from 'runsystem',
    it raises an exception; it doesn't return the usual command
    line response of 'command not found'.
  * The fix is to check for the error that gets raised for
    unrecognized cli commands.
- Refactor the parsing method used in 'analyze'
- Fix some issues there too
  * Didn't work correctly for components with >1 vulnerability
  * Didn't always build the correct npm dependency trees
  * 'relative_path' assumes its second arg (@trigger.path) is an abs path,
    but @trigger.path can be relative (at least when run locally)
  * Didn't report all vulnerable files if a js-lib vulnerability
    was found in more than one file
- Make the fingerprint more unique
  * If a component had two vulnerabilities with the same severity
    they'd have the same fingerprint.
  * Added the 'detail' (description of the vulnerability) to the
    fingerprint input string.

Some of these fixes were needed due to recent changes in RetireJS.