### PR TITLE
added support for zap passive mode

### DIFF
--- a/lib/glue/options.rb
+++ b/lib/glue/options.rb
@@ -180,6 +180,9 @@ module Glue::Options
         opts.on "--zap-port PORT", "Specify the port ZAP is running on." do |port|
           options[:zap_port] = port
         end
+        opts.on "--zap-passive-mode", "Specify the port ZAP is running on." do
+            options[:zap_passive_mode] = true
+          end
 
         opts.separator ""
         opts.separator "Scout options:"

--- a/lib/glue/tasks/zap.rb
+++ b/lib/glue/tasks/zap.rb
@@ -21,7 +21,14 @@ class Glue::Zap < Glue::BaseTask
     rootpath = @trigger.path
     base = "#{@tracker.options[:zap_host]}:#{@tracker.options[:zap_port]}"
     apikey = "#{@tracker.options[:zap_api_token]}"
+    mode = @tracker.options[:zap_passive_mode]
     context = SecureRandom.uuid
+
+    if (mode)
+        # Result
+        @result = Curl.get("#{base}/JSON/core/view/alerts/?baseurl=#{rootpath}").body_str
+        return
+    end
 
     Glue.debug "Running ZAP on: #{rootpath} from #{base} with #{context}"
     puts "Running ZAP on: #{rootpath} from #{base} with #{context}"


### PR DESCRIPTION
You can also use Zap as a proxy, listening for traffic in a previous step (for example, use it to proxy existing UI automation). Than, you can use Glue to request the alerts. I added a new flag `zap-passive-mode`. When set, Glue will only retrieve all the alert for the given target.