### PR TITLE
added file filter

### DIFF
--- a/lib/glue/filters/file_filter.rb
+++ b/lib/glue/filters/file_filter.rb
@@ -1,0 +1,49 @@
+require 'glue/filters/base_filter'
+require 'jira-ruby'
+require 'date'
+
+class Glue::FileFilter < Glue::BaseFilter
+
+  Glue::Filters.add self
+
+  def initialize
+    @name = "File Filter"
+    @description = "Checks that each issue against exisiting issues status file"
+  end
+
+  def filter tracker
+    exisiting_finding = {}
+    if (File.exist? tracker.options[:finding_file_path])
+        exisiting_finding = JSON.parse!(File.read tracker.options[:finding_file_path])
+    end
+    
+    potential_findings = Array.new(tracker.findings)
+    tracker.findings.clear
+    
+    for finding in potential_findings do
+        if (!exisiting_finding.key? finding.fingerprint)
+            exisiting_finding[finding.fingerprint] = "new"
+        end
+
+        if exisiting_finding[finding.fingerprint] == "new" 
+            tracker.report finding
+        elsif exisiting_finding[finding.fingerprint].starts_with? "postpone:"
+            date_raw = exisiting_finding[finding.fingerprint].split("postpone:")[1]
+            begin
+                date = Date.strptime(date_raw, "%d-%m-%Y")
+                if (date <= Date.today)
+                    tracker.report finding
+                end
+            rescue => e
+                Glue.error "failed to parse date: #{e}"
+            end
+        end
+    end
+
+    File.open(tracker.options[:finding_file_path], 'w') {|f| f << JSON.pretty_generate(exisiting_finding)}
+
+    return tracker.findings
+  end
+
+
+end

--- a/spec/filters/file_filter/file_filter_spec.rb
+++ b/spec/filters/file_filter/file_filter_spec.rb
@@ -1,0 +1,136 @@
+require 'spec_helper'
+
+require 'glue'
+require 'glue/event'
+require 'glue/tracker'
+require 'glue/finding'
+require 'glue/filters'
+require 'glue/filters/file_filter'
+
+describe Glue::FileFilter do
+  LOCAL_TEST_DIR = 'spec/filters/file_filter/targets'
+
+  before do
+    @tracker = Glue::Tracker.new({})
+    @tracker.report Glue::Finding.new( "test", "test", "test", "test", 1, "fingerprint1", self.class.name )
+    @tracker.report Glue::Finding.new( "test", "test", "test", "test", 1, "fingerprint2", self.class.name )
+    @empty_file_name = File.join(Dir.pwd, LOCAL_TEST_DIR, "empty.json")
+    @ignore_file_name = File.join(Dir.pwd, LOCAL_TEST_DIR, "finding_ignore.json")
+    @partial_file_name = File.join(Dir.pwd, LOCAL_TEST_DIR, "finding_partial.json")
+    @postpone_file_name = File.join(Dir.pwd, LOCAL_TEST_DIR, "finding_postpone.json")
+    @postpone_passed_file_name = File.join(Dir.pwd, LOCAL_TEST_DIR, "finding_postpone_passed.json")
+  end
+
+  describe "filter" do
+    subject {Glue::FileFilter.new()}
+    describe "finding file does not exist" do
+        before do 
+            @tracker.options[:finding_file_path] = @empty_file_name
+        end
+
+        after do 
+            if File.exist? @empty_file_name
+                File.delete @empty_file_name
+            end
+        end
+
+        it "should write all finding to file with state 'new'" do
+            subject.filter(@tracker)
+            results = JSON.parse!(File.read @empty_file_name)
+            expect(results.length).to eq(2)
+            expect(results["fingerprint1"]).to eq("new")
+            expect(results["fingerprint2"]).to eq("new")
+        end
+
+        it "should not filter the results" do
+            current_findings = Array.new(@tracker.findings)
+            subject.filter(@tracker)
+            expect(@tracker.findings).to eq(current_findings)
+        end
+    end
+
+    describe "finding file contains ignored findings" do
+        before do 
+            @tracker.options[:finding_file_path] = @ignore_file_name
+        end
+
+        it "should not change the file" do
+            subject.filter(@tracker)
+            puts @ignore_file_name
+            results = JSON.parse!(File.read @ignore_file_name)
+            expect(results.length).to eq(2)
+            expect(results["fingerprint1"]).to eq("ignore")
+            expect(results["fingerprint2"]).to eq("new")
+        end
+
+        it "should filter the results" do
+            subject.filter(@tracker)
+            expect(@tracker.findings.length).to eq(1)
+        end
+    end
+
+    describe "finding file contains partial results" do
+        before do 
+            @tracker.options[:finding_file_path] = @partial_file_name
+        end
+
+        it "should not change the file" do
+            subject.filter(@tracker)
+            puts @ignore_file_name
+            results = JSON.parse!(File.read @partial_file_name)
+            expect(results.length).to eq(2)
+            expect(results["fingerprint1"]).to eq("ignore")
+            expect(results["fingerprint2"]).to eq("new")
+        end
+
+        it "should filter the results" do
+            subject.filter(@tracker)
+            expect(@tracker.findings.length).to eq(1)
+        end
+    end
+
+    describe "finding file contains postponed results" do
+        before do 
+            @tracker.options[:finding_file_path] = @postpone_file_name
+        end
+
+        it "should not change the file" do
+            subject.filter(@tracker)
+            puts @ignore_file_name
+            results = JSON.parse!(File.read @postpone_file_name)
+            expect(results.length).to eq(2)
+            expect(results["fingerprint1"]).to eq("postpone:1-1-2999")
+            expect(results["fingerprint2"]).to eq("new")
+        end
+
+        it "should filter the results" do
+            subject.filter(@tracker)
+            expect(@tracker.findings.length).to eq(1)
+        end
+    end
+
+    describe "finding file contains postponed results" do
+        before do 
+            @tracker.options[:finding_file_path] = @postpone_passed_file_name
+        end
+
+        it "should not change the file" do
+            subject.filter(@tracker)
+            puts @ignore_file_name
+            results = JSON.parse!(File.read @postpone_passed_file_name)
+            expect(results.length).to eq(2)
+            expect(results["fingerprint1"]).to eq("postpone:1-1-1")
+            expect(results["fingerprint2"]).to eq("new")
+        end
+
+        it "should filter the results" do
+            subject.filter(@tracker)
+            expect(@tracker.findings.length).to eq(2)
+        end
+    end
+  end
+
+  # The "::matches?" method was tested implicitly in the tests for "#analyze"
+  # (all of the allowed combinations were included there)
+  # so no explicit tests for it are done here.
+end

--- a/spec/filters/file_filter/targets/finding_ignore.json
+++ b/spec/filters/file_filter/targets/finding_ignore.json
@@ -1,0 +1,4 @@
+{
+  "fingerprint1": "ignore",
+  "fingerprint2": "new"
+}

--- a/spec/filters/file_filter/targets/finding_partial.json
+++ b/spec/filters/file_filter/targets/finding_partial.json
@@ -1,0 +1,4 @@
+{
+  "fingerprint1": "ignore",
+  "fingerprint2": "new"
+}

--- a/spec/filters/file_filter/targets/finding_postpone.json
+++ b/spec/filters/file_filter/targets/finding_postpone.json
@@ -1,0 +1,4 @@
+{
+  "fingerprint1": "postpone:1-1-2999",
+  "fingerprint2": "new"
+}

--- a/spec/filters/file_filter/targets/finding_postpone_passed.json
+++ b/spec/filters/file_filter/targets/finding_postpone_passed.json
@@ -1,0 +1,4 @@
+{
+  "fingerprint1": "postpone:1-1-1",
+  "fingerprint2": "new"
+}


### PR DESCRIPTION
A filter that ignores findings based on the fingerprint. The filtering is done based on `json` file, where you can define the status:
 - new: the issue will be reported
 - postpone: postpone until a specific date
 - ignore: the issue will not be reported
Next step is to create some utility to update this file.
close #63.