### PR TITLE
added Zap's Information risk level

### DIFF
--- a/lib/glue/tasks/base_task.rb
+++ b/lib/glue/tasks/base_task.rb
@@ -17,7 +17,7 @@ class Glue::BaseTask
     @trigger = trigger
     @tracker = tracker
     @severity_filter = {
-      :low => ['low','weak'],
+      :low => ['low','weak', 'informational'],
       :medium => ['medium','med','average'],
       :high => ['high','severe','critical']
     }


### PR DESCRIPTION
According to this [line](https://github.com/zaproxy/zaproxy/blob/30d249eee369d804ec8fb5842bc2b449248a1f10/src/org/parosproxy/paros/core/scanner/Alert.java#L178), Zap has support for four levels: `{"Informational", "Low", "Medium", "High"}`. Low, medium and high are already supported and mapped to the correct level in Glue, I added `Information` level which should be mapped to `Low`.