### PR TITLE
clean up to create small docker image with only glue installed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec :name => "owasp-glue"
 
-gem "rake"
-gem "rspec"
-gem 'aruba', '~> 0.14.2'
+gem "rake", :group => :test
+gem "rspec", :group => :test
+gem 'aruba', '~> 0.14.2', :group => :test
 gem 'httparty'

--- a/docker/glue/Dockerfile-raw
+++ b/docker/glue/Dockerfile-raw
@@ -1,5 +1,7 @@
 FROM ruby:2.4-alpine
 
+LABEL maintainer="mkonda@jemurai.com"
+
 WORKDIR /glue
 
 RUN apk add --update build-base curl-dev

--- a/docker/glue/Dockerfile-raw
+++ b/docker/glue/Dockerfile-raw
@@ -1,0 +1,15 @@
+FROM ruby:2.4-alpine
+
+WORKDIR /glue
+
+RUN apk add --update build-base curl-dev
+
+COPY Gemfile Gemfile.lock glue.gemspec /glue/
+COPY ./bin/glue /glue/bin/glue
+COPY ./lib/glue/version.rb /glue/lib/glue/
+
+RUN bundle install --without development test
+
+COPY /lib /glue/lib
+
+CMD ./bin/glue

--- a/glue.gemspec
+++ b/glue.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency "jsonpath", ">= 0.5.7"
   s.add_dependency "nokogiri", ">=1.6.6.2"
   s.add_dependency "rake"
-  s.add_dependency "dawnscanner", ">= 1.6.0"
   s.add_dependency "redcarpet"
   s.add_dependency "jira-ruby"
   s.add_dependency "httparty"

--- a/lib/glue/tasks/npm.rb
+++ b/lib/glue/tasks/npm.rb
@@ -1,7 +1,6 @@
 require 'glue/tasks/base_task'
 require 'glue/util'
 require 'find'
-require 'pry'
 
 class Glue::Npm < Glue::BaseTask
 


### PR DESCRIPTION
I've tried to create a small image as possible - the image is currently only 274 MB, and I'm sure this can be improved. The base ruby image is only 54 MB, so we can do a lot to improve :)

As part of the cleanup, I've tried to remove gems that require additional libraries. This is why I removed `dawnscanner`, which is dependent on `sqlite3` gem. Installing this gem requires more libraries to install and bigger image size. As the code is not dependent directly on this gem, I think it is safe to remove, and it will be re-installed but those who need it.

`pry` was required in one file, but it was installed as dev dependency. As it looked that it is not used in the code, I felt safe to remove it. I also marked other libraries as `test` dependencies, so they will not be installed in the docker file.