### PR TITLE
Normalize the unknown criticality for bundle-audit tool

### DIFF
--- a/lib/glue/tasks/bundle-audit.rb
+++ b/lib/glue/tasks/bundle-audit.rb
@@ -45,6 +45,14 @@ class Glue::BundleAudit < Glue::BaseTask
   end
 
   private
+  def normalize_unknown_severity sev
+    sev = '' if sev.nil?
+    return sev if sev.strip.chomp.downcase != "unknown"
+    Glue.warn "Criticality: Unknown. Setting it to medium"
+    return "medium"
+  end
+
+  private
   def get_warnings
     @results.each do |dir, result|
       detail, jem, source, sev, hash = '','',{},'',''
@@ -71,7 +79,7 @@ class Glue::BundleAudit < Glue::BaseTask
           source = { :scanner => @name, :file => "#{relative_path(dir, @trigger.path)}/Gemfile.lock", :line => nil, :code => nil }
           hash << value
         when 'Criticality'
-          sev = severity(value)
+          sev = severity(normalize_unknown_severity(value))
           hash << sev
         when 'URL'
           detail += line.chomp.split('URL:').last


### PR DESCRIPTION
## What

This PR intends to change the bundler-audit task criticality classification from "Unknown" To "medium". 

## Rationale

[Bundler-Audit](https://github.com/rubysec/bundler-audit) is a tool for:
>Patch-level verification for bundler

It uses the [ruby-advisory-db](https://github.com/rubysec/ruby-advisory-db) as its vulnerability database, which is all great and dandy except, it has a lot of CVEs with value _"Unknown"_. There's an obvious good reason for this. Sometimes the lastest and greatest, _"bleeding edge"_ vulnerabilities are not yet classified.

This leads to a lot of exceptions from Glue, since its behaviour assumes that if a vulnerability doesn't have a defined Severity (a.k.a. Criticality), the test should not be accounted for and an exception should be raised.

Considering that bundler-audit is a very useful tool, this change is being made.

### Why medium

Several options were on the table (e.g., adding a new severity class to glue), however, without making much changes this appeared to be the one with least impact to the rest of the codebase.