### PR TITLE
Fix retirejs task

### DIFF
--- a/lib/glue/tasks/retirejs.rb
+++ b/lib/glue/tasks/retirejs.rb
@@ -88,7 +88,7 @@ class Glue::RetireJS < Glue::BaseTask
     return [] if all_results.nil?
 
     js_results, npm_results = all_results.partition do |result|
-      result.key?('file')
+      result[0].eql? 'file'
     end
 
     js_vulnerabilities(js_results) + npm_vulnerabilities(npm_results)
@@ -188,6 +188,9 @@ class Glue::RetireJS < Glue::BaseTask
   end
 
   def vulnerability_hashes(proto_result, source_tag)
+    if !proto_result.has_key?('vulnerabilities') then
+      return []
+    end
     proto_result['vulnerabilities'].each_with_object([]) do |vuln, vulns|
       vuln_hash = {
         package: package_tag(proto_result),


### PR DESCRIPTION
This PR fixes the broken `retirejs.rb` task, which fails and ultimately does not print the base report.

After debugging the code, the following problems were found and fixed:
* `retirejs.rb:91` - call to `key?` on object `result` of type Array.
* `retirejs.rb:191` - acess to `vulnerabilities` key without verifying its existence, leads to failure if retrieved value is nil.