### PR TITLE
Updating Glue Dockerfile to include both RVM signing keys.

### DIFF
--- a/docker/glue/Dockerfile
+++ b/docker/glue/Dockerfile
@@ -27,9 +27,7 @@ USER glue
 #       RVM / Ruby
 #
 #
-RUN curl -sSL https://rvm.io/mpapis.asc | gpg --import -
-RUN curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
-RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+RUN gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN /bin/bash -l -c "curl -L https://get.rvm.io | bash -s stable"
 RUN /bin/bash -l -c "source ~/.rvm/scripts/rvm"
 RUN /bin/bash -l -c "rvm requirements"


### PR DESCRIPTION
This updates the gpg key import command to also pull the pkuczynski key using the command syntax contained in the [RVM documentation](https://rvm.io/rvm/security). 

Without this, RVM builds signed by pkuczynski instead of mpapis cause the image build to fail.