### PR TITLE
Azure DevOps mounter

### DIFF
--- a/lib/glue/mounters/azdo_mounter.rb
+++ b/lib/glue/mounters/azdo_mounter.rb
@@ -1,0 +1,54 @@
+require 'glue/mounters/base_mounter'
+require 'fileutils'
+
+class Glue::AzDOMounter < Glue::BaseMounter
+
+  Glue::Mounters.add self
+
+  def initialize trigger, options
+    super(trigger)
+    @options = options
+    @name = "AzDO Git"
+    @description = "Pull a repo."
+  end
+
+  def mount target
+    base = @options[:working_dir]
+
+    Glue.debug "Making base."
+    FileUtils.mkdir_p base
+
+    # Grab the path used as git url, excluding PAT.
+    # format of this target must be https://DUMMY:<PAT_TOKEN>@dev.azure.com/<account>/<project>/_git/<repository>
+    protocol, azdo_domain, account, project, repository = target.match(/\A(.*\/\/).*@(.*)\/(.*)\/(.*)\/_git\/(.+?)[\/]{0,1}\z/i).captures
+
+    path = [azdo_domain, account, project, repository].map{|i| '/'+i}.join
+    working_target = File.expand_path(base + "" + path + "/")
+
+    Glue.notify "Cleaning directory: #{working_target}"
+    if ! Dir.exists? working_target
+      Glue.notify "#{working_target} is not a directory."
+      FileUtils.mkdir_p working_target
+    else
+      Glue.debug "Removing : #{working_target}"
+      FileUtils.rm_rf working_target
+      FileUtils.mkdir_p working_target
+    end
+      # result = `rm -rf #{working_target}`
+      # puts result
+    Glue.debug "Cloning into: #{working_target}"
+    result = `git clone -q #{target} #{working_target}`
+    # puts result
+    #end
+    return working_target
+  end
+
+  def supports? target
+    if target.include?("@dev.azure.com/") && target.include?("/_git/")
+      return true
+    else
+      return false
+    end
+  end
+
+end

--- a/lib/glue/mounters/url_mounter.rb
+++ b/lib/glue/mounters/url_mounter.rb
@@ -19,6 +19,8 @@ class Glue::URLMounter < Glue::BaseMounter
     last = target.slice(-4,target.length)
     if last === ".git"
       return false
+    elsif target.include?("@dev.azure.com/") && target.include?("/_git/")
+      return false
     elsif start === "http"
       return true
     else


### PR DESCRIPTION
GitMounter lacks the ability of mounting git repositories from [Azure DevOps ](https://docs.microsoft.com/en-us/azure/devops/user-guide/code-with-git?view=azure-devops)

I decided to create a new mounter, heavily inspired by the git one, to be able to mount Azure DevOps (aka Visual Studio Team Services) git repositories when they are specified as a target

format of the target URL should be:

```
https://DUMMY:<PAT_TOKEN>@dev.azure.com/<account>/<project>/_git/<repository>
```

It requires a _Personal Access Token_ to be used as part of the target url, and having, at least, Code/Read capabilities against such repository, as specified in this [link](https://docs.microsoft.com/en-us/azure/devops/repos/git/auth-overview?view=azure-devops)

sample of the tool mounting an Azure Devops repository and starting scanning the content:
```
/glue # ./bin/glue -t brakeman -f json  https://test:XXXXXXXXX@dev.azure.com/XXXXX/XXXXX/_git/XXXXX
Logfile nil?
calling scan
Running scanner
Loading scanner...
Mounting https://test:XXXXXXXXX@dev.azure.com/XXXXX/XXXXX/_git/XXXXX with #<Glue::AzDOMounter:0x00005572e7ac9090>
Cleaning directory: /root/glue/tmp/dev.azure.com/XXXXX/XXXXX/XXXXX
/root/glue/tmp/dev.azure.com/XXXXX/XXXXX/XXXXXis not a directory.
Mounted https://test:XXXXXXXXX@dev.azure.com/XXXXX/XXXXX/_git/XXXXX with #<Glue::AzDOMounter:0x00005572e7ac9090>
Processing target...https://test:XXXXXXXXX@dev.azure.com/XXXXX/XXXXX/_git/XXXXX
Running tasks in stage: wait
Running tasks in stage: mount
Running tasks in stage: file
```

Concern is having PAT tokens leaking on logs, so might be useful to redact that from the base mounters files. 

Also, thinking on allowing PAT token to be a configuration option and use it for this mounter instead of using targets including tokens as part of the string