### PR TITLE
Added option to set JIRA issue type in JIRA reporter

### DIFF
--- a/lib/glue/options.rb
+++ b/lib/glue/options.rb
@@ -151,6 +151,9 @@ module Glue::Options
         opts.on "--jira-default-priority PRIORITY", "Specify a default priority for JIRA issues. This will override the mapping of severity to priority." do |default_priority|
           options[:jira_default_priority] = default_priority
         end
+        opts.on "--jira-issue-type ISSUETYPE", "Specify issue type to use when rasing issues." do |jira_issue_type|
+          options[:jira_issue_type] = jira_issue_type
+        end
 
         opts.separator ""
         opts.separator "Pivotal options:"

--- a/lib/glue/reporters/jira_reporter.rb
+++ b/lib/glue/reporters/jira_reporter.rb
@@ -42,7 +42,7 @@ class Glue::JiraReporter < Glue::BaseReporter
     tracker.findings.each do |finding|
       begin
         issue = @jira.Issue.build
-        json = get_jira_json(finding, tracker.options[:jira_skip_fields] || '', tracker.options[:jira_default_priority])
+        json = get_jira_json(finding, tracker.options[:jira_skip_fields] || '', tracker.options[:jira_default_priority], tracker.options[:jira_issue_type])
         issue.save(json)
       rescue Exception => e
         puts "Issue #{e.message}"
@@ -52,7 +52,7 @@ class Glue::JiraReporter < Glue::BaseReporter
   end
 
   private
-  def get_jira_json(finding, skip_fields, default_priority=nil)
+  def get_jira_json(finding, skip_fields, default_priority=nil, issue_type=nil)
 	  json = {
     	"fields": {
        		"project":
@@ -65,7 +65,7 @@ class Glue::JiraReporter < Glue::BaseReporter
             'name': jira_priority(finding.severity, default_priority)
           },
        		"issuetype": {
-          		"name": "Bug"
+          		"name": jira_issue_type(issue_type)
        		},       		
        		#{}"components": [ { "name": "#{@component}" } ]
        	}
@@ -77,6 +77,14 @@ class Glue::JiraReporter < Glue::BaseReporter
 
     json['labels'] = [ "Glue", "#{finding.appname}" ] unless skip_fields.split(',').include?('labels')
     json
+  end
+
+  def jira_issue_type(issue_type)
+    if issue_type.empty?
+      return "Bug"
+    end
+
+    issue_type
   end
 
   def jira_priority(severity, default_priority=nil)

--- a/lib/glue/reporters/jira_reporter.rb
+++ b/lib/glue/reporters/jira_reporter.rb
@@ -80,7 +80,7 @@ class Glue::JiraReporter < Glue::BaseReporter
   end
 
   def jira_issue_type(issue_type)
-    if issue_type.empty?
+    if issue_type.to_s.empty?
       return "Bug"
     end
 

--- a/spec/reporters/jira_reporter_spec.rb
+++ b/spec/reporters/jira_reporter_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+require 'glue'
+require 'glue/event'
+require 'glue/tracker'
+require 'glue/finding'
+require 'glue/reporters'
+require 'glue/reporters/jira_reporter'
+
+describe Glue::JiraReporter do
+
+    describe "JIRA Reporter" do
+        subject {Glue::JiraReporter.new()}
+
+        it "should set jira issue type to Bug when no type given" do
+            expected_output = "Bug"
+            actual_output_example_1 = subject.send("jira_issue_type", nil)
+            actual_output_example_2 = subject.send("jira_issue_type", "")
+
+            expect(expected_output).to eq(actual_output_example_1)
+            expect(expected_output).to eq(actual_output_example_2)
+        end
+
+        it "should set jira issue to type passed by the user" do
+            expected_output = "Story"
+            actual_output = subject.send("jira_issue_type", "Story")
+
+            expect(expected_output).to eq(actual_output)
+        end
+
+    end
+end


### PR DESCRIPTION
**Summary**

Currently, Glue assumes when raising issues that they should be of type _Bug_. However not all JIRA projects might have this issue type so Glue should support overriding this if required.

**Change**

Added an option **--jira-issue-type** to allow a user to pass in the issue type they want to be used when the JIRA reporter raises issues in JIRA. If this is not set it uses the default value **Bug**.

cc @omerlh 