### PR TITLE
Enabled external database support in OWASP Dependency Check.

### DIFF
--- a/docker/glue/Dockerfile
+++ b/docker/glue/Dockerfile
@@ -71,6 +71,10 @@ WORKDIR /home/glue/tools/
 RUN curl -L http://dl.bintray.com/jeremy-long/owasp/dependency-check-1.4.3-release.zip --output owasp-dep-check.zip
 RUN unzip owasp-dep-check.zip
 
+# PostgreSQL JDBC Plugin (for external database)
+#
+RUN curl -L https://jdbc.postgresql.org/download/postgresql-42.2.5.jar --output /home/glue/tools/dependency-check/plugins/postgresql.jar
+
 # Maven
 RUN sudo apt-get install -y maven
 

--- a/lib/glue/options.rb
+++ b/lib/glue/options.rb
@@ -258,6 +258,25 @@ module Glue::Options
           options[:owasp_dep_check_suppression] = path
         end
 
+        opts.on "--owasp-db-driver-name NAME", "The Java class name for the OWASP Dependency Check external database driver" do |driver_name|
+          Glue.debug "Setting OWASP DB Driver name to #{driver_name}"
+          options[:owasp_dep_check_db_driver_name] = driver_name
+        end
+
+        opts.on "--owasp-db-connection-string URL", "The connection string for the OWASP Dependency Check external database" do |db_conn_string|
+          Glue.debug "Setting OWASP DB connection string to #{db_conn_string}"
+          options[:owasp_dep_check_db_conn_string] = db_conn_string
+        end
+
+        opts.on "--owasp-db-user USER", "The user for the OWASP Dependency Check external database" do |db_user|
+          Glue.debug "Setting OWASP DB user to #{db_user}"
+          options[:owasp_dep_check_db_user] = db_user
+        end
+
+        opts.on "--owasp-db-password PASSWORD", "The password for the OWASP Dependency Check external database" do |db_password|
+          options[:owasp_dep_check_db_pass] = db_password
+        end
+
         opts.on "--sbt-path PATH", "The full path to sbt (optional)" do |path|
           options[:sbt_path] = path
         end

--- a/lib/glue/tasks/owasp-dep-check.rb
+++ b/lib/glue/tasks/owasp-dep-check.rb
@@ -128,6 +128,22 @@ class Glue::OWASPDependencyCheck < Glue::BaseTask
       run_args << [ "--suppression", "#{@tracker.options[:owasp_dep_check_suppression]}" ]
     end
 
+    if @tracker.options[:owasp_dep_check_db_driver_name]
+      run_args << [ "--dbDriverName", "#{@tracker.options[:owasp_dep_check_db_driver_name]}" ]
+    end
+
+    if @tracker.options[:owasp_dep_check_db_conn_string]
+      run_args << [ "--connectionString", "#{@tracker.options[:owasp_dep_check_db_conn_string]}" ]
+    end
+
+    if @tracker.options[:owasp_dep_check_db_user]
+      run_args << [ "--dbUser", "#{@tracker.options[:owasp_dep_check_db_user]}" ]
+    end
+
+    if @tracker.options[:owasp_dep_check_db_pass]
+      run_args << [ "--dbPassword", "#{@tracker.options[:owasp_dep_check_db_pass]}" ]
+    end
+
     run_args << [ "-out", "#{rootpath}", "-s", "#{rootpath}" ] unless @scala_project || @gradle_project || @maven_project
 
     initial_dir = Dir.pwd


### PR DESCRIPTION
- Updated OWASP Dependency Check task to parse options for external CVE database. 
- Added PostgreSQL plugin to docker image to allow use of external Postgres databases in Docker image.

This enables glue to optionally use a separate, persistent database for OWASP Dependency Check. Doing so enables the use of this task from the Glue docker image (or other Glue system of your choice) without needing to download and process the CVE lists on each run and without baking the database into the image. OWASP Dependency Check does not automatically initialize the appropriate tables, so the external database must be initialized out-of-band using the SQL scripts from the upstream Dependency Check repository.

This can be used in commands like: `glue --owasp-db-driver-name org.postgresql.Driver --owasp-db-connection-string jdbc:postgresql://dependencycheck-postgresql.svc.cluster.local/dependencycheck --owasp-db-user dependencycheck --owasp-db-pass $OWASP_DB_PASS -t OWASPDependencyCheck .`