### PR TITLE
Update slack reporter to put findings in an attachement to avoid a massive message

### DIFF
--- a/lib/glue/reporters/slack_reporter.rb
+++ b/lib/glue/reporters/slack_reporter.rb
@@ -46,7 +46,7 @@ class Glue::SlackReporter < Glue::BaseReporter
     puts tracker.options[:slack_channel]
 
     begin
-      client.chat_postMessage(channel: tracker.options[:slack_channel], text: "OWASP Glue found some issues. Raised as a message attachment.", attachments: reports.join << "\n", as_user: post_as_user)
+      client.chat_postMessage(channel: tracker.options[:slack_channel], text: "OWASP Glue test run completed - See attachment.", attachments: reports.join << "\n", as_user: post_as_user)
     rescue Slack::Web::Api::Error => error
       Glue.fatal "Post to slack failed: " << error.to_s
     end

--- a/lib/glue/reporters/slack_reporter.rb
+++ b/lib/glue/reporters/slack_reporter.rb
@@ -46,7 +46,7 @@ class Glue::SlackReporter < Glue::BaseReporter
     puts tracker.options[:slack_channel]
 
     begin
-      client.chat_postMessage(channel: tracker.options[:slack_channel], text: reports.join << "\n", as_user: post_as_user)
+      client.chat_postMessage(channel: tracker.options[:slack_channel], text: "OWASP Glue found some issues. Raised as a message attachment.", attachments: reports.join << "\n", as_user: post_as_user)
     rescue Slack::Web::Api::Error => error
       Glue.fatal "Post to slack failed: " << error.to_s
     end

--- a/spec/reporters/slack_reporter_spec.rb
+++ b/spec/reporters/slack_reporter_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+require 'glue'
+require 'glue/event'
+require 'glue/tracker'
+require 'glue/finding'
+require 'glue/reporters'
+require 'glue/reporters/slack_reporter'
+
+describe Glue::SlackReporter do
+
+    before do
+        @tracker = Glue::Tracker.new({
+            slack_token: "",
+            slack_channel: ""
+        })
+
+        @tracker.report Glue::Finding.new( "finding_appname",
+            "finding_description",
+            "finding_detail",
+            "finding_test",
+            1,
+            "fingerprint_1",
+            "finding_task" )
+      end
+
+    describe "Slack Reporter" do
+        subject {Glue::SlackReporter.new()}
+
+        it "should report findings as a slack message with an attachment" do
+            # Stub out requests to Slack API
+            stub_request(:post, "https://slack.com/api/auth.test")
+                .to_return(status: 200, body: "", headers: {})
+
+            stub_request(:post, "https://slack.com/api/chat.postMessage")
+                .to_return(status: 200, body: "", headers: {})
+
+            
+            # Build slack report
+            subject.run_report(@tracker)
+
+            # Check slack client made request to send message with attachment for findings
+            WebMock.should have_requested(:post, "https://slack.com/api/chat.postMessage")
+                .with{|req|
+                    req.body.include?("attachments=%0A%09Description%3A+finding_description")
+                    req.body.include?("text=OWASP+Glue+test+run+completed+-+See+attachment.")
+                }
+        end
+    end
+end


### PR DESCRIPTION
**Summary**

Currently, the Slack reporter puts all the findings from glue into one big formatted string and sends this as a message to slack. However, depending on how long this message gets it can flood a channel.
Instead by setting the message as an attachment the message will be collapsed after 700 chars or 5+ line breaks. (see https://api.slack.com/docs/message-attachments - Attachment Params, Text to see more. I know the docs are out of date but testing myself suggests the rule is still true).

**Change**

Instead of sending a large message now the bot sends a message saying it has results and then a text attachment with the results in it.