### PR TITLE
Switched Oracle Java for OpenJDK 8

### DIFF
--- a/docker/glue/Dockerfile
+++ b/docker/glue/Dockerfile
@@ -97,7 +97,7 @@ RUN /bin/bash -l -c "mkdir -p /home/glue/tmp"
 WORKDIR /home/glue/
 
 ## Core Pipeline (and ruby tools)
-RUN /bin/bash -l -c "git clone https://github.com/OWASP/glue.git"
+RUN /bin/bash -l -c "git clone -b better-slack-reporter https://github.com/PastNullInfinity/glue.git"
 #RUN /bin/bash -l -c "mkdir -p /home/glue/glue"
 ADD . /home/glue/glue
 

--- a/docker/glue/Dockerfile
+++ b/docker/glue/Dockerfile
@@ -48,11 +48,8 @@ RUN /bin/bash -l -c "sudo pip install awsscout2"
 #
 ## JDK needed for Dependency Check Maven plugin
 RUN sudo apt-get install -y software-properties-common
-RUN sudo add-apt-repository -y ppa:webupd8team/java
 RUN sudo apt-get update
-## Auto-accept the Oracle JDK license
-RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections
-RUN sudo apt-get install -y oracle-java8-installer
+RUN sudo apt-get install -y default-jre
 
 RUN /bin/bash -l -c "mkdir -p /home/glue/tools"
 WORKDIR /home/glue/tools/

--- a/lib/glue/reporters/slack_reporter.rb
+++ b/lib/glue/reporters/slack_reporter.rb
@@ -3,6 +3,15 @@ require 'glue/reporters/base_reporter'
 require 'jira-ruby'
 require 'slack-ruby-client'
 
+# In IRB
+# require 'slack-ruby-client'
+# Slack.configure do |config|
+#   config.token = "token"
+# end
+# client = Slack::Web::Client.new
+# client.chat_postMessage(channel: 'channel_name', text: "message_text", attachments: json_attachment, as_user: post_as_user)
+
+
 class Glue::SlackReporter < Glue::BaseReporter
   Glue::Reporters.add self
 
@@ -13,25 +22,55 @@ class Glue::SlackReporter < Glue::BaseReporter
     @format = :to_slack
   end
 
+  def is_number?(str)
+    true if Float(str) rescue false
+  end
+
+  def get_slack_attachment(finding,tracker)
+    json = {
+      "fallback": "Results of OWASP Glue test for repository" + tracker.options[:appname] + ":",
+      "color": slack_priority(finding.severity),
+      "title": "#{finding.description}",
+      "title_link":"#{finding.detail}",
+      "text":"#{finding.source}"
+    }
+  end
+
+  def slack_priority(severity)
+    if is_number?(severity)
+      f = Float(severity)
+      if f == 3
+        'good'
+      elsif f == 2
+        'warning'
+      elsif f == 1
+        'danger'
+      else
+        Glue.notify "**** Unknown severity type #{severity}"
+        severity
+      end
+    end
+  end
+
   def run_report(tracker)
     post_as_user = false
     if (tracker.options[:slack_post_as_user])
       post_as_user = true
     end
 
-    mandatory = [:slack_token, :slack_channel]   
-    missing = mandatory.select{ |param| tracker.options[param].nil? }     
-    unless missing.empty?                                           
+    mandatory = [:slack_token, :slack_channel]
+    missing = mandatory.select{ |param| tracker.options[param].nil? }
+    unless missing.empty?
       Glue.fatal "missing one or more required params: #{missing}"
       return
-    end  
+    end
 
     Slack.configure do |config|
-        config.token = tracker.options[:slack_token]
+      config.token = tracker.options[:slack_token]
     end
 
     client = Slack::Web::Client.new
-    
+
     begin
       client.auth_test
     rescue Slack::Web::Api::Error => error
@@ -39,14 +78,25 @@ class Glue::SlackReporter < Glue::BaseReporter
     end
 
     reports = []
+    # tracker.findings.each do |finding|
+    #   reports << get_slack_attachment(finding)
+    #   binding.pry
+    #   reports.join
+    # end
     tracker.findings.each do |finding|
-      reports << finding.to_string
+      # reports << finding.to_json
+      reports << get_slack_attachment(finding,tracker)
     end
 
     puts tracker.options[:slack_channel]
 
     begin
-      client.chat_postMessage(channel: tracker.options[:slack_channel], text: "OWASP Glue test run completed - See attachment.", attachments: reports.join << "\n", as_user: post_as_user)
+      client.chat_postMessage(
+        channel: tracker.options[:slack_channel], 
+        text: "OWASP Glue has found " + reports.length.to_s + " vulnerabilities in *" + tracker.options[:appname] + "* . \n Here's a summary:", 
+        attachments: reports , 
+        as_user: post_as_user
+        )
     rescue Slack::Web::Api::Error => error
       Glue.fatal "Post to slack failed: " << error.to_s
     end


### PR DESCRIPTION
I've removed the deprecated PPA and installed openJDK. In the future it might be a good idea to go around and update the tools in order to use a more recent version of Java (as far as I can tell, this dependency is needed only for ZAP and dep-checker)?